### PR TITLE
Add Kumuluzee implementation support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" 
+  xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.mehmandarov</groupId>
   <artifactId>qrcreator</artifactId>
   <version>1.0-SNAPSHOT</version>
-  <packaging>war</packaging>
+  <packaging>${packaging.type}</packaging>
   <properties>
     <openliberty.maven.version>2.2</openliberty.maven.version>
     <failOnMissingWebXml>false</failOnMissingWebXml>
     <openliberty.version>RELEASE</openliberty.version>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <kumuluzee.version>3.5.0</kumuluzee.version>
   </properties>
   <dependencies>
     <dependency>
@@ -61,6 +63,50 @@
     </plugins>
   </build>
   <profiles>
+    <profile>
+      <id>kumuluzee</id>
+      <properties>
+        <packaging.type>jar</packaging.type>
+      </properties>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-bom</artifactId>
+            <version>${kumuluzee.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>com.kumuluz.ee</groupId>
+          <artifactId>kumuluzee-microProfile-2.2</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.kumuluz.ee</groupId>
+          <artifactId>kumuluzee-servlet-jetty</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.kumuluz.ee</groupId>
+            <artifactId>kumuluzee-maven-plugin</artifactId>
+            <version>${kumuluzee.version}</version>
+            <executions>
+              <execution>
+                <id>package</id>
+                <goals>
+                  <goal>repackage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>liberty</id>
       <activation>
@@ -121,6 +167,7 @@
         </plugins>
       </build>
       <properties>
+        <packaging.type>war</packaging.type>
         <httpsPort>8543</httpsPort>
         <!--<jwt.issuer>https://server.example.com</jwt.issuer>-->
         <openliberty.version>RELEASE</openliberty.version>

--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
Hi,

I propose to you this PR to add Kumuluzee implementation support for your project.

I don't have impacted the _README.md_ file since I want to you give me your opinion about this improvement.

Note, I need to copy the _beans.xml_ file into the _src/main/resources/META_INF_ because a Kumuluzee needs to be packaged into a Jar file. In fact, I don't know OpenLiberty implementation and how it's possible to switch War to Jar packaging file. 

To compile with Kumuluzee implementation

`mvn clean package -P kumuluzee`

To run

`PORT=3000 java -jar target/qrcreator.jar`

To test: <http://localhost:3000/index.html>

Thx for your advise

Mickael
